### PR TITLE
Implement rapidcheck for variant spec

### DIFF
--- a/proj/dtgen/variant/render.py
+++ b/proj/dtgen/variant/render.py
@@ -164,7 +164,7 @@ def get_typename(*, spec: VariantSpec, qualified: bool) -> str:
 
 def render_namespaced_typename(spec: VariantSpec, f: TextIO) -> None:
     f.write(f'{spec.namespace}::')
-    render_typename(spec, f)
+    render_typename(spec=spec, f=f)
 
 def render_hash_decl(spec: VariantSpec, f: TextIO) -> None:
     typename = get_typename(spec=spec, qualified=True)
@@ -442,8 +442,8 @@ def render_impls(spec: VariantSpec, f: TextIO) -> None:
     if Feature.JSON in spec.features:
         render_json_impl(spec=spec, f=f)
     
-    # if Feature.RAPIDCHECK in spec.features:
-    #     render_rapidcheck_impl(spec=spec, f=f)
+    if Feature.RAPIDCHECK in spec.features:
+        render_rapidcheck_impl(spec=spec, f=f)
 
     if Feature.FMT in spec.features:
         render_fmt_impl(spec=spec, f=f)

--- a/proj/dtgen/variant/render.py
+++ b/proj/dtgen/variant/render.py
@@ -26,6 +26,7 @@ from proj.dtgen.render_utils import (
     render_default_case,
     angles,
     parens,
+    commad,
 )
 import io
 import itertools
@@ -160,6 +161,10 @@ def get_typename(*, spec: VariantSpec, qualified: bool) -> str:
     f = io.StringIO() 
     render_typename(spec=spec, qualified=qualified, f=f)
     return f.getvalue()
+
+def render_namespaced_typename(spec: StructSpec, f: TextIO) -> None:
+    f.write(f'{spec.namespace}::')
+    render_typename(spec, f)
 
 def render_hash_decl(spec: VariantSpec, f: TextIO) -> None:
     typename = get_typename(spec=spec, qualified=True)
@@ -323,22 +328,32 @@ def render_fmt_impl(spec: VariantSpec, f: TextIO) -> None:
                 f.write('return s << fmt::to_string(x)')
 
 def render_rapidcheck_decl(spec: VariantSpec, f: TextIO) -> None:
-    typename = get_typename(spec=spec, qualified=True)
+    # typename = get_typename(spec=spec, qualified=True)
 
+    # with render_namespace_block('rc', f):
+    #     with render_struct_block(
+    #         name=f'Arbitrary<{typename}>',
+    #         template_params=[],
+    #         specialization=True,
+    #         f=f,
+    #     ):
+    #         render_function_declaration(
+    #             is_static=True,
+    #             return_type=f'Gen<{typename}>',
+    #             name='arbitrary',
+    #             args=[],
+    #             f=f,
+    #         )
     with render_namespace_block('rc', f):
-        with render_struct_block(
-            name=f'Arbitrary<{typename}>',
-            template_params=[],
-            specialization=True,
-            f=f,
-        ):
-            render_function_declaration(
-                is_static=True,
-                return_type=f'Gen<{typename}>',
-                name='arbitrary',
-                args=[],
-                f=f,
-            )
+        with semicolon(f):
+            f.write('struct Arbitrary')
+            with angles(f):
+                render_namespaced_typename(spec, f)
+            with braces(f):
+                f.write('static Gen')
+                with angles(f):
+                    render_namespaced_typename(spec, f)
+                f.write(' arbitrary();\n')
 
 def render_rapidcheck_impl(spec: VariantSpec, f: TextIO) -> None:
     with render_namespace_block('rc', f):
@@ -437,8 +452,8 @@ def render_impls(spec: VariantSpec, f: TextIO) -> None:
     if Feature.JSON in spec.features:
         render_json_impl(spec=spec, f=f)
     
-    if Feature.RAPIDCHECK in spec.features:
-        render_rapidcheck_impl(spec=spec, f=f)
+    # if Feature.RAPIDCHECK in spec.features:
+    #     render_rapidcheck_impl(spec=spec, f=f)
 
     if Feature.FMT in spec.features:
         render_fmt_impl(spec=spec, f=f)

--- a/proj/dtgen/variant/render.py
+++ b/proj/dtgen/variant/render.py
@@ -343,19 +343,20 @@ def render_rapidcheck_decl(spec: VariantSpec, f: TextIO) -> None:
 def render_rapidcheck_impl(spec: VariantSpec, f: TextIO) -> None:
     typename = get_typename(spec=spec, qualified=True)
 
-    with render_function_definition(
-            return_type=f'Gen<{typename}>',
-            name=f'Arbitrary<{typename}>::arbitrary',
-            args=[],
-            f=f,
-        ):
-        with sline(f):
-            f.write('return gen::oneOf')
-            with parens(f):
-                for value in commad(spec.values, f):
-                    f.write(f'gen::cast<{typename}>')
-                    with parens(f):
-                        f.write(f'gen::arbitrary<{value.type_}>()')
+    with render_namespace_block('rc', f):
+        with render_function_definition(
+                return_type=f'Gen<{typename}>',
+                name=f'Arbitrary<{typename}>::arbitrary',
+                args=[],
+                f=f,
+            ):
+            with sline(f):
+                f.write('return gen::oneOf')
+                with parens(f):
+                    for value in commad(spec.values, f):
+                        f.write(f'gen::cast<{typename}>')
+                        with parens(f):
+                            f.write(f'gen::arbitrary<{value.type_}>()')
 
 def render_variant_type(spec: VariantSpec, f: TextIO) -> None:
     render_template_app('std::variant', [v.type_ for v in spec.values], f=f)

--- a/proj/dtgen/variant/render.py
+++ b/proj/dtgen/variant/render.py
@@ -24,6 +24,8 @@ from proj.dtgen.render_utils import (
     render_switch_block,
     render_case,
     render_default_case,
+    angles,
+    parens,
 )
 import io
 import itertools

--- a/proj/dtgen/variant/render.py
+++ b/proj/dtgen/variant/render.py
@@ -164,7 +164,7 @@ def get_typename(*, spec: VariantSpec, qualified: bool) -> str:
 
 def render_namespaced_typename(spec: VariantSpec, f: TextIO) -> None:
     f.write(f'{spec.namespace}::')
-    render_typename(spec=spec, qualified=True, f=f)
+    render_typename(spec=spec, qualified=False, f=f)
 
 def render_hash_decl(spec: VariantSpec, f: TextIO) -> None:
     typename = get_typename(spec=spec, qualified=True)
@@ -356,12 +356,14 @@ def render_rapidcheck_impl(spec: VariantSpec, f: TextIO) -> None:
         f.write('::arbitrary() ')
         with braces(f):
             with semicolon(f):
-                f.write('return gen::construct')
-                with angles(f):
-                    render_namespaced_typename(spec, f)
+                f.write('return gen::oneOf')
                 with parens(f):
                     for value in commad(spec.values, f):
-                        f.write(f'gen::arbitrary<{value.type_}>()')
+                        f.write('gen::cast')
+                        with angles(f):
+                            render_namespaced_typename(spec, f)
+                        with parens(f):
+                            f.write(f'gen::arbitrary<{value.type_}>()')
 
 def render_variant_type(spec: VariantSpec, f: TextIO) -> None:
     render_template_app('std::variant', [v.type_ for v in spec.values], f=f)

--- a/proj/dtgen/variant/render.py
+++ b/proj/dtgen/variant/render.py
@@ -164,7 +164,7 @@ def get_typename(*, spec: VariantSpec, qualified: bool) -> str:
 
 def render_namespaced_typename(spec: VariantSpec, f: TextIO) -> None:
     f.write(f'{spec.namespace}::')
-    render_typename(spec=spec, f=f)
+    render_typename(spec=spec, qualified=True, f=f)
 
 def render_hash_decl(spec: VariantSpec, f: TextIO) -> None:
     typename = get_typename(spec=spec, qualified=True)

--- a/proj/dtgen/variant/render.py
+++ b/proj/dtgen/variant/render.py
@@ -320,7 +320,7 @@ def render_fmt_impl(spec: VariantSpec, f: TextIO) -> None:
             with sline(f):
                 f.write('return s << fmt::to_string(x)')
 
-def render_rapidcheck_decl(spec: StructSpec, f: TextIO) -> None:
+def render_rapidcheck_decl(spec: VariantSpec, f: TextIO) -> None:
     with render_namespace_block('rc', f):
         render_template_abs(spec.template_params, f)
         with semicolon(f):
@@ -333,7 +333,7 @@ def render_rapidcheck_decl(spec: StructSpec, f: TextIO) -> None:
                     render_namespaced_typename(spec, f)
                 f.write(' arbitrary();\n')
 
-def render_rapidcheck_impl(spec: StructSpec, f: TextIO) -> None:
+def render_rapidcheck_impl(spec: VariantSpec, f: TextIO) -> None:
     with render_namespace_block('rc', f):
         if len(spec.template_params) > 0:
             render_template_abs(spec.template_params, f)

--- a/proj/dtgen/variant/render.py
+++ b/proj/dtgen/variant/render.py
@@ -452,8 +452,8 @@ def render_impls(spec: VariantSpec, f: TextIO) -> None:
     if Feature.JSON in spec.features:
         render_json_impl(spec=spec, f=f)
     
-    # if Feature.RAPIDCHECK in spec.features:
-    #     render_rapidcheck_impl(spec=spec, f=f)
+    if Feature.RAPIDCHECK in spec.features:
+        render_rapidcheck_impl(spec=spec, f=f)
 
     if Feature.FMT in spec.features:
         render_fmt_impl(spec=spec, f=f)

--- a/proj/dtgen/variant/render.py
+++ b/proj/dtgen/variant/render.py
@@ -328,32 +328,22 @@ def render_fmt_impl(spec: VariantSpec, f: TextIO) -> None:
                 f.write('return s << fmt::to_string(x)')
 
 def render_rapidcheck_decl(spec: VariantSpec, f: TextIO) -> None:
-    # typename = get_typename(spec=spec, qualified=True)
+    typename = get_typename(spec=spec, qualified=True)
 
-    # with render_namespace_block('rc', f):
-    #     with render_struct_block(
-    #         name=f'Arbitrary<{typename}>',
-    #         template_params=[],
-    #         specialization=True,
-    #         f=f,
-    #     ):
-    #         render_function_declaration(
-    #             is_static=True,
-    #             return_type=f'Gen<{typename}>',
-    #             name='arbitrary',
-    #             args=[],
-    #             f=f,
-    #         )
     with render_namespace_block('rc', f):
-        with semicolon(f):
-            f.write('struct Arbitrary')
-            with angles(f):
-                render_namespaced_typename(spec, f)
-            with braces(f):
-                f.write('static Gen')
-                with angles(f):
-                    render_namespaced_typename(spec, f)
-                f.write(' arbitrary();\n')
+        with render_struct_block(
+            name=f'Arbitrary<{typename}>',
+            template_params=[],
+            specialization=True,
+            f=f,
+        ):
+            render_function_declaration(
+                is_static=True,
+                return_type=f'Gen<{typename}>',
+                name='arbitrary',
+                args=[],
+                f=f,
+            )
 
 def render_rapidcheck_impl(spec: VariantSpec, f: TextIO) -> None:
     with render_namespace_block('rc', f):
@@ -452,8 +442,8 @@ def render_impls(spec: VariantSpec, f: TextIO) -> None:
     if Feature.JSON in spec.features:
         render_json_impl(spec=spec, f=f)
     
-    if Feature.RAPIDCHECK in spec.features:
-        render_rapidcheck_impl(spec=spec, f=f)
+    # if Feature.RAPIDCHECK in spec.features:
+    #     render_rapidcheck_impl(spec=spec, f=f)
 
     if Feature.FMT in spec.features:
         render_fmt_impl(spec=spec, f=f)

--- a/proj/dtgen/variant/render.py
+++ b/proj/dtgen/variant/render.py
@@ -162,7 +162,7 @@ def get_typename(*, spec: VariantSpec, qualified: bool) -> str:
     render_typename(spec=spec, qualified=qualified, f=f)
     return f.getvalue()
 
-def render_namespaced_typename(spec: StructSpec, f: TextIO) -> None:
+def render_namespaced_typename(spec: VariantSpec, f: TextIO) -> None:
     f.write(f'{spec.namespace}::')
     render_typename(spec, f)
 

--- a/proj/dtgen/variant/spec.py
+++ b/proj/dtgen/variant/spec.py
@@ -21,7 +21,7 @@ class Feature(Enum):
     HASH = auto()
     JSON = auto()
     FMT = auto()
-    # RAPIDCHECK = auto()
+    RAPIDCHECK = auto()
 
     def json(self) -> Json:
         return self.name
@@ -92,6 +92,8 @@ def parse_feature(raw: str) -> Feature:
         return Feature.JSON
     elif raw == 'fmt':
         return Feature.FMT
+    elif raw == 'rapidcheck':
+        return Feature.RAPIDCHECK
     else:
         raise ValueError(f'Unknown feature: {raw}')
 

--- a/tests/dtgen/person/include/int_or_bool.variant.toml
+++ b/tests/dtgen/person/include/int_or_bool.variant.toml
@@ -5,6 +5,7 @@ features = [
   "ord",
   "hash",
   "json",
+  "rapidcheck",
   "fmt",
 ]
 includes = []

--- a/tests/dtgen/person/test/test_int_or_bool.cc
+++ b/tests/dtgen/person/test/test_int_or_bool.cc
@@ -208,5 +208,10 @@ TEST_SUITE(FF_TEST_SUITE) {
     CHECK(result == correct);
   }
 
+  TEST_CASE("rapidcheck example") {
+    rc::check([&](IntOrBool const &x) {
+      CHECK(x.has<int>() || x.has<bool>());
+    });
+  }
 
 }


### PR DESCRIPTION
Implemented rapidcheck arbitrary generation for variant.toml files.

Variant arbitrary generators implemented as
` gen::oneOf(gen::cast<std::variant<Ts...>>(gen::arbitrary<Ts>())...);`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lockshaw/proj/3)
<!-- Reviewable:end -->
