### PR TITLE
CodeCov support

### DIFF
--- a/proj/__main__.py
+++ b/proj/__main__.py
@@ -52,7 +52,7 @@ def cmake(cmake_args, config, is_coverage):
         [
             "cmake",
             *cmake_args,
-            "..",
+            "../..",
         ],
         stderr=sys.stdout,
         cwd=cwd,
@@ -122,7 +122,6 @@ def main_build(args: Any) -> None:
 def main_test(args: Any) -> None:
     config = lockshaw.get_config(args.path)
     assert config is not None
-    cwd = config.build_dir
     if args.coverage:
         cwd = config.cov_dir
     else:
@@ -177,7 +176,7 @@ def main_test(args: Any) -> None:
                 "lcov", 
                 "--extract",
                 "main_coverage.info",
-                "lib/*",
+                f"{config.base}/lib/*",
                 "--output-file",
                 "main_coverage.info",
             ],

--- a/proj/__main__.py
+++ b/proj/__main__.py
@@ -173,6 +173,30 @@ def main_test(args: Any) -> None:
             cwd=cwd,
             env=os.environ,
         )
+        
+        subprocess_run(
+            [
+                "lcov", 
+                "--remove",
+                "main_coverage.info",
+                "/nix/store/*",
+                "--output-file",
+                "main_coverage.info",
+            ],
+            stderr=sys.stdout,
+            cwd=cwd,
+            env=os.environ,
+        )
+        subprocess_run(
+            [
+                "lcov",
+                "--list",
+                "main_coverage.info",
+            ],
+            stderr=sys.stdout,
+            cwd=cwd,
+            env=os.environ,
+        )
         if args.browser:
             print("opening coverage info in browser")
             subprocess_run(

--- a/proj/__main__.py
+++ b/proj/__main__.py
@@ -95,8 +95,7 @@ def main_cmake(args: Any) -> None:
             env=os.environ,
         )
         
-    cmake_args += ["-DFF_USE_CODE_COVERAGE=ON"]
-    cmake(cmake_args, config, True)
+    cmake(cmake_args + ["-DFF_USE_CODE_COVERAGE=ON"], config, True)
 
 
 def main_build(args: Any) -> None:

--- a/proj/fix_compile_commands.py
+++ b/proj/fix_compile_commands.py
@@ -17,7 +17,7 @@ def load_options_file(p: Path) -> List[str]:
 def get_relpath(entry, base_dir: Path):
     file = Path(entry["file"])
     directory = Path(entry["directory"])
-    reldir = directory.relative_to(base_dir / "build")
+    reldir = directory.relative_to(base_dir / "build/normal")
     relative = file.relative_to(base_dir / reldir)
     return relative
 

--- a/proj/lockshaw_config.py
+++ b/proj/lockshaw_config.py
@@ -33,11 +33,11 @@ class ProjectConfig:
 
     @property
     def build_dir(self) -> Path:
-        return self.base / "build"
+        return self.base / "build/normal"
     
     @property
     def cov_dir(self) -> Path:
-        return self.base / "build_codecov"
+        return self.base / "build/codecov"
 
     @property
     def build_targets(self) -> Tuple[str, ...]:

--- a/proj/lockshaw_config.py
+++ b/proj/lockshaw_config.py
@@ -34,6 +34,10 @@ class ProjectConfig:
     @property
     def build_dir(self) -> Path:
         return self.base / "build"
+    
+    @property
+    def cov_dir(self) -> Path:
+        return self.base / "build_codecov"
 
     @property
     def build_targets(self) -> Tuple[str, ...]:


### PR DESCRIPTION
**Description of changes:**

- ```proj cmake``` will create two separate build folders. build and build_codecov. Additional flag FF_USE_CODE_COVERAGE is added to achieve the optional instrumentation in cmake
- use ```proj test --coverage``` will generate coverage info in terminal. ```proj test --coverage --browser``` will run the report in user's browser(if have one)
- filtered the coverage information and currently, only code in lib/ will be covered (can change the scope of coverage very easily if needed)
- codecov is supported. The codecov report can be visualized and PR in the future will support automatic code coverage comment

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lockshaw/proj/6)
<!-- Reviewable:end -->
