### PR TITLE
rm codecoverage for dtgen

### DIFF
--- a/proj/__main__.py
+++ b/proj/__main__.py
@@ -219,6 +219,8 @@ def main_test(args: MainTestArgs) -> None:
             env=os.environ,
         )
         
+        # only keep the coverage info of the lib directory
+        print("remove dtgen!")
         subprocess_run(
             [
                 "lcov", 
@@ -232,6 +234,23 @@ def main_test(args: MainTestArgs) -> None:
             cwd=cwd,
             env=os.environ,
         )
+        
+        # filter out dtg.h and .dtg.cc
+        subprocess_run(
+            [
+                "lcov",
+                "--remove",
+                "main_coverage.info",
+                f"{config.base}/lib/*.dtg.h",
+                f"{config.base}/lib/*.dtg.cc",
+                "--output-file",
+                "main_coverage.info",
+            ],
+            stderr=sys.stdout,
+            cwd=cwd,
+            env=os.environ,
+        )
+        
         if args.browser:
             print("opening coverage info in browser")
             subprocess_run(

--- a/proj/__main__.py
+++ b/proj/__main__.py
@@ -220,7 +220,6 @@ def main_test(args: MainTestArgs) -> None:
         )
         
         # only keep the coverage info of the lib directory
-        print("remove dtgen!")
         subprocess_run(
             [
                 "lcov", 

--- a/proj/config_file.py
+++ b/proj/config_file.py
@@ -29,7 +29,11 @@ class ProjectConfig:
 
     @property
     def build_dir(self) -> Path:
-        return self.base / 'build'
+        return self.base / 'build/normal'
+    
+    @property
+    def cov_dir(self) -> Path:
+        return self.base / 'build/codecov'
 
     @property
     def build_targets(self) -> Tuple[str, ...]:


### PR DESCRIPTION
rm codecoverage for files ends with dtg.h and .dtg.cc

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lockshaw/proj/9)
<!-- Reviewable:end -->
