### PR TITLE
spec file gen and cmake change

### DIFF
--- a/proj/__main__.py
+++ b/proj/__main__.py
@@ -76,7 +76,7 @@ def cmake(cmake_args, config, is_coverage):
 @dataclass(frozen=True)
 class MainCmakeArgs:
     path: Path
-    force: bool
+    fast: bool
     trace: bool
 
 def main_cmake(args: MainCmakeArgs) -> None:
@@ -88,7 +88,7 @@ def main_cmake(args: MainCmakeArgs) -> None:
     ))
 
     config = get_config(args.path)
-    if args.force:
+    if not args.fast:
         if config.build_dir.exists():
             shutil.rmtree(config.build_dir)
         if config.cov_dir.exists():
@@ -381,7 +381,7 @@ def main() -> None:
     cmake_p = subparsers.add_parser("cmake")
     cmake_p.set_defaults(func=main_cmake)
     cmake_p.add_argument("--path", "-p", type=Path, default=Path.cwd())
-    cmake_p.add_argument("--force", "-f", action="store_true")
+    cmake_p.add_argument("--fast", action="store_true")
     cmake_p.add_argument("--trace", action="store_true")
     add_verbosity_args(cmake_p)
 

--- a/proj/dtgen/project.py
+++ b/proj/dtgen/project.py
@@ -124,12 +124,11 @@ def needs_generate_to_path(spec_path: Path, root: Path, out: Path) -> bool:
     if not out.is_file():
         return True
 
-    current_hash = get_existing_hash(p=out)
-    new_hash = get_file_hash(spec_path)
-    assert new_hash is not None
+    spec_mtime = spec_path.stat().st_mtime
+    out_mtime = out.stat().st_mtime
 
-    _l.debug(f'Hash diff: {new_hash!r} vs {current_hash!r}')
-    return new_hash != current_hash
+    _l.debug(f'Spec modified time: {spec_mtime!r} vs Out modified time {out_mtime!r}')
+    return spec_mtime > out_mtime
 
 def generate_header(spec: Union[StructSpec, EnumSpec, VariantSpec], spec_path: Path, root: Path, out: Path, force: bool) -> bool:
     if not (force or needs_generate_to_path(spec_path=spec_path, root=root, out=out)):


### PR DESCRIPTION
cmake
- changed the current --force to be the new default
- added --fast flag to invoke the current default

spec file gen
- changed file gen logic from identifying different hashes to identifying spec file modified time > out file modified time.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lockshaw/proj/10)
<!-- Reviewable:end -->
